### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ git:
 sudo: false
 
 php:
-- 5.6
-- 7.0
 - 7.1
 - 7.2
+- 7.3
+- 7.4
 - hhvm
 - nightly
 

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,16 @@
             "email": "zhuravel.r@centrobill.com"
         }
     ],
-    "require": {},
+    "require": {
+        "php": ">=7.1"
+    },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.11 || ^6.4 || ^7.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "files": [
             "./src/functions.php"
-        ],
-        "psr-4": {
-            "LuhnAlgorithm\\": "src/"
-        }
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/IsValidLuhnChecksumTest.php
+++ b/tests/IsValidLuhnChecksumTest.php
@@ -67,6 +67,7 @@ class IsValidLuhnChecksumTest extends TestCase
             [79927398715],
             [79927398716],
             [79927398719],
+            [null],
         ];
     }
 }


### PR DESCRIPTION
# Changed log

- Drop `php-5.6` and `php-7.0` because it's time to require `php-7.1` version at least.
- Drop `^5.7` and `^6.5` versions about `PHPUnit` and it should require `^7.1` version at least.
- Add the `null` test case for `IsValidLuhnChecksumTest` class.